### PR TITLE
URLがhttpsになる事象の改善

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,3 +1,10 @@
+<?php
+if (empty($_SERVER['HTTPS'])) {
+    header("Location: https://nxlottery.azurewebsites.net/".$_GET["txt"]);
+    exit;
+}
+?>
+
 <!DOCTYPE html>
 <html lang="ja">
 <head>


### PR DESCRIPTION
ssl通信以外(http)で接続された場合、ssl通信での接続(https)にリダイレクトするようにしました。